### PR TITLE
Fix seed script to parse NDJSON format data file

### DIFF
--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -99,23 +99,13 @@ async function seed() {
       }
     }
 
-    // Read and parse JSON data
+    // Read and parse NDJSON data (one JSON object per line)
     console.log('📖 Reading data file...');
     const rawData = fs.readFileSync(DATA_FILE, 'utf8');
-    const data = JSON.parse(rawData);
-
-    // Convert object to array of documents
-    const documents = [];
-    for (const [areaName, items] of Object.entries(data)) {
-      if (Array.isArray(items)) {
-        for (const item of items) {
-          documents.push({
-            Areaname: areaName,
-            ...item
-          });
-        }
-      }
-    }
+    const documents = rawData
+      .split('\n')
+      .filter(line => line.trim())
+      .map(line => JSON.parse(line));
 
     if (documents.length === 0) {
       console.error('❌ No documents found in data file');


### PR DESCRIPTION
The data file (id_county_item.json) contains newline-delimited JSON
(one JSON object per line), but the seed script was calling JSON.parse()
on the entire file contents, which fails because it's not valid JSON as
a whole. Split by newlines and parse each line individually.

https://claude.ai/code/session_01MGJ4Yh1BQm4i3ofBFfyWMq